### PR TITLE
feat: enhance layout normalization with robust validation and testing (closes #7)

### DIFF
--- a/figgo.go
+++ b/figgo.go
@@ -27,10 +27,25 @@ func convertParserFont(pf *parser.Font) *Font {
 	if pf == nil {
 		return nil
 	}
+
+	// Normalize layout from header values
+	normalized, err := NormalizeLayoutFromHeader(pf.OldLayout, pf.FullLayout, pf.FullLayoutSet)
+	if err != nil {
+		// If normalization fails, fall back to old behavior
+		// This should rarely happen as the parser validates the values
+		normalized = NormalizedLayout{
+			HorzMode: ModeFull,
+			VertMode: ModeFull,
+		}
+	}
+
+	// Convert normalized layout to Layout bitmask
+	layout := normalized.ToLayout()
+
 	return &Font{
 		Glyphs:         pf.Characters,
-		Name:           "",                                // Will be set based on filename or metadata
-		FullLayout:     Layout(pf.FullLayout % (1 << 32)), //nolint:gosec // Overflow handled by modulo
+		Name:           "", // Will be set based on filename or metadata
+		FullLayout:     layout,
 		Hardblank:      pf.Hardblank,
 		Height:         pf.Height,
 		Baseline:       pf.Baseline,

--- a/figgo.go
+++ b/figgo.go
@@ -85,21 +85,24 @@ func convertToParserFont(f *Font) *parser.Font {
 		Baseline:       f.Baseline,
 		MaxLength:      f.MaxLen,
 		OldLayout:      f.OldLayout,
-		FullLayout:     int(f.FullLayout),
+		// Note: We don't set FullLayout here as f.FullLayout is the normalized
+		// layout bitmask, not the original FIGfont header value
 		PrintDirection: f.PrintDirection,
 		CommentLines:   f.CommentLines,
 		Characters:     f.Glyphs,
 	}
 }
 
-// validateLayout checks for layout conflicts
+// validateLayout checks for layout conflicts and normalizes the layout
 func validateLayout(opts *options) error {
 	if opts.layout != nil {
-		layout := *opts.layout
-		// Check if both FitKerning and FitSmushing are set
-		if (layout&FitKerning != 0) && (layout&FitSmushing != 0) {
-			return ErrLayoutConflict
+		// Use NormalizeLayout to check for all conflicts
+		normalized, err := NormalizeLayout(*opts.layout)
+		if err != nil {
+			return err
 		}
+		// Update with normalized layout
+		*opts.layout = normalized
 	}
 	return nil
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -64,6 +64,9 @@ type Font struct {
 	// FullLayout contains the full layout value
 	FullLayout int
 
+	// FullLayoutSet indicates whether FullLayout was present in the header
+	FullLayoutSet bool
+
 	// CodetagCount specifies the number of code-tagged characters
 	CodetagCount int
 }
@@ -275,6 +278,7 @@ func parseOptionalFields(fields []string, font *Font) error {
 	if len(fields) > fullLayoutField {
 		if val, err := strconv.Atoi(fields[fullLayoutField]); err == nil {
 			font.FullLayout = val
+			font.FullLayoutSet = true
 		}
 	}
 

--- a/internal/parser/parser_bench_test.go
+++ b/internal/parser/parser_bench_test.go
@@ -89,7 +89,7 @@ func BenchmarkParseGlyph(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				scanner := strings.NewReader(content)
 				s := bufio.NewScanner(scanner)
-				_, _ = parseGlyph(s, tt.height, 100)
+				_, _, _ = parseGlyph(s, tt.height, 100)
 			}
 		})
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -49,6 +49,9 @@ More comments here
 				if f.FullLayout != 24463 {
 					t.Errorf("FullLayout = %d, want %d", f.FullLayout, 24463)
 				}
+				if !f.FullLayoutSet {
+					t.Errorf("FullLayoutSet = false, want true (FullLayout field is present)")
+				}
 				if f.CodetagCount != 229 {
 					t.Errorf("CodetagCount = %d, want %d", f.CodetagCount, 229)
 				}
@@ -86,6 +89,9 @@ Comment 2
 				if f.FullLayout != 0 {
 					t.Errorf("FullLayout = %d, want %d", f.FullLayout, 0)
 				}
+				if f.FullLayoutSet {
+					t.Errorf("FullLayoutSet = true, want false (no FullLayout field)")
+				}
 			},
 		},
 		{
@@ -94,6 +100,21 @@ Comment 2
 			validate: func(t *testing.T, f *Font) {
 				if f.Signature != testSignature {
 					t.Errorf("Signature = %q, want %q", f.Signature, testSignature)
+				}
+				if f.Height != 8 {
+					t.Errorf("Height = %d, want %d", f.Height, 8)
+				}
+			},
+		},
+		{
+			name:  "header_with_utf8_bom",
+			input: "\uFEFFflf2a$ 8 6 14 15 1 0 0\nComment line\n",
+			validate: func(t *testing.T, f *Font) {
+				if f.Signature != testSignature {
+					t.Errorf("Signature = %q, want %q", f.Signature, testSignature)
+				}
+				if f.Hardblank != '$' {
+					t.Errorf("Hardblank = %q, want %q", f.Hardblank, '$')
 				}
 				if f.Height != 8 {
 					t.Errorf("Height = %d, want %d", f.Height, 8)
@@ -251,6 +272,23 @@ Comment
 			validate: func(t *testing.T, f *Font) {
 				if f.PrintDirection != 1 {
 					t.Errorf("PrintDirection = %d, want %d", f.PrintDirection, 1)
+				}
+				if f.FullLayoutSet {
+					t.Errorf("FullLayoutSet = true, want false (only 6 fields, no FullLayout)")
+				}
+			},
+		},
+		{
+			name: "header_with_fulllayout_zero",
+			input: `flf2a$ 8 6 14 15 1 0 0
+Comment
+`,
+			validate: func(t *testing.T, f *Font) {
+				if f.FullLayout != 0 {
+					t.Errorf("FullLayout = %d, want %d", f.FullLayout, 0)
+				}
+				if !f.FullLayoutSet {
+					t.Errorf("FullLayoutSet = false, want true (FullLayout field present even if 0)")
 				}
 			},
 		},

--- a/layout_normalization_test.go
+++ b/layout_normalization_test.go
@@ -200,6 +200,46 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		// Both-bits-set precedence tests
+		{
+			name:          "Horizontal: both fitting(64) and smushing(128) -> smushing wins",
+			oldLayout:     0,
+			fullLayout:    64 + 128, // Both horizontal fitting and smushing
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal, // Smushing wins, no rules = universal
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Vertical: both fitting(8192) and smushing(16384) -> smushing wins",
+			oldLayout:     0,
+			fullLayout:    8192 + 16384, // Both vertical fitting and smushing
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeSmushingUniversal, // Smushing wins, no rules = universal
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Both H and V: fitting+smushing -> smushing wins on both axes",
+			oldLayout:     0,
+			fullLayout:    64 + 128 + 8192 + 16384 + 3, // Both bits set + some H rules
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled, // Smushing wins, with rules
+				HorzRules: 0x03,                   // Rules 1+2
+				VertMode:  ModeSmushingUniversal,  // Smushing wins, no V rules
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
 		// Precedence tests
 		{
 			name:          "FullLayout overrides OldLayout when set",

--- a/layout_normalization_test.go
+++ b/layout_normalization_test.go
@@ -1,0 +1,346 @@
+package figgo
+
+import (
+	"testing"
+)
+
+func TestNormalizeLayoutFromOldLayout(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldLayout     int
+		fullLayout    int
+		fullLayoutSet bool
+		want          NormalizedLayout
+		wantErr       bool
+	}{
+		// OldLayout only tests
+		{
+			name:          "OldLayout -1 -> Full width",
+			oldLayout:     -1,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout 0 -> Fitting (kerning)",
+			oldLayout:     0,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeFitting,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout 1 -> Smushing with rule 1",
+			oldLayout:     1,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x01, // Rule 1
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout 3 -> Smushing with rules 1+2",
+			oldLayout:     3,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x03, // Rules 1+2
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout 63 -> Smushing with all 6 rules",
+			oldLayout:     63,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x3F, // All 6 rules
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout -2 -> Invalid",
+			oldLayout:     -2,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want:          NormalizedLayout{},
+			wantErr:       true,
+		},
+		{
+			name:          "OldLayout 64 -> Invalid",
+			oldLayout:     64,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want:          NormalizedLayout{},
+			wantErr:       true,
+		},
+		// FullLayout only tests
+		{
+			name:          "FullLayout 0 with set flag -> Full/Full",
+			oldLayout:     0,
+			fullLayout:    0,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 64 -> Horizontal Fitting",
+			oldLayout:     0,
+			fullLayout:    64,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFitting,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 128 -> Horizontal Universal Smushing",
+			oldLayout:     0,
+			fullLayout:    128,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 129 -> Horizontal Controlled Smushing with rule 1",
+			oldLayout:     0,
+			fullLayout:    129, // 128 + 1
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x01,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 8192 -> Vertical Fitting",
+			oldLayout:     0,
+			fullLayout:    8192,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeFitting,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 16384 -> Vertical Universal Smushing",
+			oldLayout:     0,
+			fullLayout:    16384,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeSmushingUniversal,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 16640 -> Vertical Controlled Smushing with rule 1",
+			oldLayout:     0,
+			fullLayout:    16640, // 16384 + 256
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeSmushingControlled,
+				VertRules: 0x01,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout with both H and V smushing",
+			oldLayout:     0,
+			fullLayout:    191 + 16384 + 256, // H: 128+63, V: 16384+256
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x3F, // All 6 horizontal rules
+				VertMode:  ModeSmushingControlled,
+				VertRules: 0x01, // Vertical rule 1
+			},
+			wantErr: false,
+		},
+		// Precedence tests
+		{
+			name:          "FullLayout overrides OldLayout when set",
+			oldLayout:     0,   // Would be Fitting
+			fullLayout:    128, // Universal smushing
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Conflicting Old=3, Full=128 -> Full wins",
+			oldLayout:     3,   // Would be controlled smushing
+			fullLayout:    128, // Universal smushing
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Old=-1, Full=64 -> Full wins (Fitting)",
+			oldLayout:     -1, // Would be Full width
+			fullLayout:    64, // Fitting
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFitting,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		// Invalid FullLayout tests
+		{
+			name:          "FullLayout negative -> Invalid",
+			oldLayout:     0,
+			fullLayout:    -1,
+			fullLayoutSet: true,
+			want:          NormalizedLayout{},
+			wantErr:       true,
+		},
+		{
+			name:          "FullLayout > 32767 -> Invalid",
+			oldLayout:     0,
+			fullLayout:    32768,
+			fullLayoutSet: true,
+			want:          NormalizedLayout{},
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLayoutFromHeader(tt.oldLayout, tt.fullLayout, tt.fullLayoutSet)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeLayoutFromHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.HorzMode != tt.want.HorzMode {
+					t.Errorf("HorzMode = %v, want %v", got.HorzMode, tt.want.HorzMode)
+				}
+				if got.HorzRules != tt.want.HorzRules {
+					t.Errorf("HorzRules = 0x%02X, want 0x%02X", got.HorzRules, tt.want.HorzRules)
+				}
+				if got.VertMode != tt.want.VertMode {
+					t.Errorf("VertMode = %v, want %v", got.VertMode, tt.want.VertMode)
+				}
+				if got.VertRules != tt.want.VertRules {
+					t.Errorf("VertRules = 0x%02X, want 0x%02X", got.VertRules, tt.want.VertRules)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizedLayoutToLayout(t *testing.T) {
+	tests := []struct {
+		name  string
+		input NormalizedLayout
+		want  Layout
+	}{
+		{
+			name: "Horizontal Full width",
+			input: NormalizedLayout{
+				HorzMode: ModeFull,
+				VertMode: ModeFull,
+			},
+			want: FitFullWidth,
+		},
+		{
+			name: "Horizontal Fitting (kerning)",
+			input: NormalizedLayout{
+				HorzMode: ModeFitting,
+				VertMode: ModeFull,
+			},
+			want: FitKerning,
+		},
+		{
+			name: "Horizontal Controlled Smushing with rules",
+			input: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x15, // Rules 1, 3, 5
+				VertMode:  ModeFull,
+			},
+			want: FitSmushing | RuleEqualChar | RuleHierarchy | RuleBigX,
+		},
+		{
+			name: "Horizontal Universal Smushing",
+			input: NormalizedLayout{
+				HorzMode: ModeSmushingUniversal,
+				VertMode: ModeFull,
+			},
+			want: FitSmushing, // Universal smushing has no rule bits
+		},
+		{
+			name: "All horizontal rules",
+			input: NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: 0x3F, // All 6 rules
+				VertMode:  ModeFull,
+			},
+			want: FitSmushing | RuleEqualChar | RuleUnderscore | RuleHierarchy | RuleOppositePair | RuleBigX | RuleHardblank,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.ToLayout()
+			if got != tt.want {
+				t.Errorf("ToLayout() = 0x%08X (%s), want 0x%08X (%s)",
+					uint32(got), got.String(), uint32(tt.want), tt.want.String())
+			}
+		})
+	}
+}

--- a/layout_normalization_test.go
+++ b/layout_normalization_test.go
@@ -1,10 +1,11 @@
 package figgo
 
 import (
+	"fmt"
 	"testing"
 )
 
-func TestNormalizeLayoutFromOldLayout(t *testing.T) {
+func TestNormalizeLayoutFromOldLayout(t *testing.T) { //nolint:gocognit // Test function with many test cases
 	tests := []struct {
 		name          string
 		oldLayout     int
@@ -80,8 +81,34 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:          "OldLayout -2 -> Invalid",
+			name:          "OldLayout -2 -> Fitting (alias for 0)",
 			oldLayout:     -2,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeFitting,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout -3 -> Universal Smushing",
+			oldLayout:     -3,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "OldLayout -4 -> Invalid",
+			oldLayout:     -4,
 			fullLayout:    0,
 			fullLayoutSet: false,
 			want:          NormalizedLayout{},
@@ -94,6 +121,41 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			fullLayoutSet: false,
 			want:          NormalizedLayout{},
 			wantErr:       true,
+		},
+		{
+			name:          "OldLayout 100 -> Invalid",
+			oldLayout:     100,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			want:          NormalizedLayout{},
+			wantErr:       true,
+		},
+		// Universal smushing tests
+		{
+			name:          "FullLayout 128 -> Horizontal Universal Smushing (no rules)",
+			oldLayout:     0,
+			fullLayout:    128,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout 16384 -> Vertical Universal Smushing (no rules)",
+			oldLayout:     0,
+			fullLayout:    16384,
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeSmushingUniversal,
+				VertRules: 0,
+			},
+			wantErr: false,
 		},
 		// FullLayout only tests
 		{
@@ -123,19 +185,6 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:          "FullLayout 128 -> Horizontal Universal Smushing",
-			oldLayout:     0,
-			fullLayout:    128,
-			fullLayoutSet: true,
-			want: NormalizedLayout{
-				HorzMode:  ModeSmushingUniversal,
-				HorzRules: 0,
-				VertMode:  ModeFull,
-				VertRules: 0,
-			},
-			wantErr: false,
-		},
-		{
 			name:          "FullLayout 129 -> Horizontal Controlled Smushing with rule 1",
 			oldLayout:     0,
 			fullLayout:    129, // 128 + 1
@@ -157,19 +206,6 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 				HorzMode:  ModeFull,
 				HorzRules: 0,
 				VertMode:  ModeFitting,
-				VertRules: 0,
-			},
-			wantErr: false,
-		},
-		{
-			name:          "FullLayout 16384 -> Vertical Universal Smushing",
-			oldLayout:     0,
-			fullLayout:    16384,
-			fullLayoutSet: true,
-			want: NormalizedLayout{
-				HorzMode:  ModeFull,
-				HorzRules: 0,
-				VertMode:  ModeSmushingUniversal,
 				VertRules: 0,
 			},
 			wantErr: false,
@@ -215,6 +251,19 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:          "Horizontal: conflict with no rules -> universal smushing",
+			oldLayout:     0,
+			fullLayout:    192, // 128|64 = both bits, no rules
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal, // Universal smushing (no rules)
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
 			name:          "Vertical: both fitting(8192) and smushing(16384) -> smushing wins",
 			oldLayout:     0,
 			fullLayout:    8192 + 16384, // Both vertical fitting and smushing
@@ -223,6 +272,19 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 				HorzMode:  ModeFull,
 				HorzRules: 0,
 				VertMode:  ModeSmushingUniversal, // Smushing wins, no rules = universal
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Vertical: conflict with no rules -> universal smushing",
+			oldLayout:     0,
+			fullLayout:    24576, // 16384|8192 = both bits, no rules
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeSmushingUniversal, // Universal smushing (no rules)
 				VertRules: 0,
 			},
 			wantErr: false,
@@ -245,6 +307,32 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 			name:          "FullLayout overrides OldLayout when set",
 			oldLayout:     0,   // Would be Fitting
 			fullLayout:    128, // Universal smushing
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeSmushingUniversal,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "FullLayout without any fit bits defaults to Full/Full",
+			oldLayout:     1, // Would be controlled smushing
+			fullLayout:    0, // No bits set
+			fullLayoutSet: true,
+			want: NormalizedLayout{
+				HorzMode:  ModeFull,
+				HorzRules: 0,
+				VertMode:  ModeFull,
+				VertRules: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Universal smushing when smushing bit set but no rules",
+			oldLayout:     0,
+			fullLayout:    128, // Smushing bit only, no rule bits
 			fullLayoutSet: true,
 			want: NormalizedLayout{
 				HorzMode:  ModeSmushingUniversal,
@@ -324,6 +412,203 @@ func TestNormalizeLayoutFromOldLayout(t *testing.T) {
 	}
 }
 
+func TestNormalizeLayoutFromHeader_FuzzRandom(t *testing.T) {
+	// Test a range of valid FullLayout values to ensure:
+	// - no panic
+	// - modes are valid
+	// - rule bits are within constraints
+	testValues := []int{
+		0, 1, 63, 64, 127, 128, 191, 192, 255, 256,
+		512, 1024, 2048, 4096, 8192, 16384, 24576, 32767,
+		// Some specific combinations
+		64 + 128,        // Both H fitting and smushing
+		8192 + 16384,    // Both V fitting and smushing
+		191 + 16384,     // All H bits + V smushing
+		128 + 8192 + 63, // H smush + V fit + all H rules
+	}
+
+	for _, fullLayout := range testValues {
+		t.Run(fmt.Sprintf("FullLayout_%d", fullLayout), func(t *testing.T) {
+			// Should not panic
+			result, err := NormalizeLayoutFromHeader(0, fullLayout, true)
+			if err != nil {
+				t.Fatalf("Unexpected error for valid FullLayout %d: %v", fullLayout, err)
+			}
+
+			// Validate horizontal mode
+			if result.HorzMode < ModeFull || result.HorzMode > ModeSmushingUniversal {
+				t.Errorf("Invalid HorzMode %v for FullLayout %d", result.HorzMode, fullLayout)
+			}
+
+			// Validate horizontal rules (max 6 bits = 0x3F)
+			if result.HorzRules > 0x3F {
+				t.Errorf("HorzRules 0x%02X exceeds max 0x3F for FullLayout %d", result.HorzRules, fullLayout)
+			}
+
+			// Validate vertical mode
+			if result.VertMode < ModeFull || result.VertMode > ModeSmushingUniversal {
+				t.Errorf("Invalid VertMode %v for FullLayout %d", result.VertMode, fullLayout)
+			}
+
+			// Validate vertical rules (max 5 bits = 0x1F)
+			if result.VertRules > 0x1F {
+				t.Errorf("VertRules 0x%02X exceeds max 0x1F for FullLayout %d", result.VertRules, fullLayout)
+			}
+		})
+	}
+}
+
+func TestNormalizeLayoutFromHeader_AdditionalCoverage(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldLayout     int
+		fullLayout    int
+		fullLayoutSet bool
+		wantHorzMode  AxisMode
+		wantHorzRules uint8
+		wantVertMode  AxisMode
+		wantVertRules uint8
+		wantErr       bool
+	}{
+		// FullLayout precedence tests
+		{
+			name:          "FullLayout precedence: smush no rules -> universal",
+			oldLayout:     23, // Would be controlled if used
+			fullLayout:    128,
+			fullLayoutSet: true,
+			wantHorzMode:  ModeSmushingUniversal,
+			wantHorzRules: 0,
+			wantVertMode:  ModeFull,
+			wantVertRules: 0,
+		},
+		{
+			name:          "FullLayout precedence: conflict + rule -> smushing wins",
+			oldLayout:     0, // Would be fitting if used
+			fullLayout:    128 | 64 | 1,
+			fullLayoutSet: true,
+			wantHorzMode:  ModeSmushingControlled,
+			wantHorzRules: 1, // Rule 1 set
+			wantVertMode:  ModeFull,
+			wantVertRules: 0,
+		},
+		{
+			name:          "OldLayout fallback: controlled with specific rules",
+			oldLayout:     23, // bits 0,1,2,4 = rules 1,2,3,5
+			fullLayout:    0,
+			fullLayoutSet: false,
+			wantHorzMode:  ModeSmushingControlled,
+			wantHorzRules: 0x17, // 0b10111 = 23
+			wantVertMode:  ModeFull,
+			wantVertRules: 0,
+		},
+		// Vertical parsing tests
+		{
+			name:          "Vertical controlled smushing with rules",
+			oldLayout:     0,
+			fullLayout:    16384 | 256 | 512, // V smush + rules 1,2
+			fullLayoutSet: true,
+			wantHorzMode:  ModeFull,
+			wantHorzRules: 0,
+			wantVertMode:  ModeSmushingControlled,
+			wantVertRules: 0x03, // Rules 1,2
+		},
+		{
+			name:          "Vertical fitting only",
+			oldLayout:     0,
+			fullLayout:    8192,
+			fullLayoutSet: true,
+			wantHorzMode:  ModeFull,
+			wantHorzRules: 0,
+			wantVertMode:  ModeFitting,
+			wantVertRules: 0,
+		},
+		// Invalid range tests
+		{
+			name:          "OldLayout -4 invalid",
+			oldLayout:     -4,
+			fullLayout:    0,
+			fullLayoutSet: false,
+			wantErr:       true,
+		},
+		{
+			name:          "FullLayout 32768 invalid",
+			oldLayout:     0,
+			fullLayout:    32768,
+			fullLayoutSet: true,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLayoutFromHeader(tt.oldLayout, tt.fullLayout, tt.fullLayoutSet)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeLayoutFromHeader() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.HorzMode != tt.wantHorzMode {
+					t.Errorf("HorzMode = %v, want %v", got.HorzMode, tt.wantHorzMode)
+				}
+				if got.HorzRules != tt.wantHorzRules {
+					t.Errorf("HorzRules = 0x%02X, want 0x%02X", got.HorzRules, tt.wantHorzRules)
+				}
+				if got.VertMode != tt.wantVertMode {
+					t.Errorf("VertMode = %v, want %v", got.VertMode, tt.wantVertMode)
+				}
+				if got.VertRules != tt.wantVertRules {
+					t.Errorf("VertRules = 0x%02X, want 0x%02X", got.VertRules, tt.wantVertRules)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeLayout_OptionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   Layout
+		want    Layout
+		wantErr bool
+	}{
+		{
+			name:    "Conflicting FitKerning|FitSmushing errors",
+			input:   FitKerning | FitSmushing,
+			wantErr: true,
+		},
+		{
+			name:    "Zero defaults to FitFullWidth",
+			input:   0,
+			want:    FitFullWidth,
+			wantErr: false,
+		},
+		{
+			name:    "Valid FitSmushing with rules preserved",
+			input:   FitSmushing | RuleEqualChar | RuleBigX,
+			want:    FitSmushing | RuleEqualChar | RuleBigX,
+			wantErr: false,
+		},
+		{
+			name:    "All three fitting modes error",
+			input:   FitFullWidth | FitKerning | FitSmushing,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLayout(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeLayout() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("NormalizeLayout() = 0x%08X, want 0x%08X", uint32(got), uint32(tt.want))
+			}
+		})
+	}
+}
+
 func TestNormalizedLayoutToLayout(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -382,5 +667,292 @@ func TestNormalizedLayoutToLayout(t *testing.T) {
 					uint32(got), got.String(), uint32(tt.want), tt.want.String())
 			}
 		})
+	}
+}
+
+// TestToLayoutMappingCompleteness verifies that each individual rule bit (0-5)
+// maps correctly to the corresponding Layout rule constant.
+func TestToLayoutMappingCompleteness(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleBit  uint8
+		wantRule Layout
+	}{
+		{"Rule 1 (bit 0) -> RuleEqualChar", 1 << 0, RuleEqualChar},
+		{"Rule 2 (bit 1) -> RuleUnderscore", 1 << 1, RuleUnderscore},
+		{"Rule 3 (bit 2) -> RuleHierarchy", 1 << 2, RuleHierarchy},
+		{"Rule 4 (bit 3) -> RuleOppositePair", 1 << 3, RuleOppositePair},
+		{"Rule 5 (bit 4) -> RuleBigX", 1 << 4, RuleBigX},
+		{"Rule 6 (bit 5) -> RuleHardblank", 1 << 5, RuleHardblank},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nl := NormalizedLayout{
+				HorzMode:  ModeSmushingControlled,
+				HorzRules: tt.ruleBit,
+				VertMode:  ModeFull,
+			}
+			got := nl.ToLayout()
+
+			// Should have FitSmushing plus the specific rule
+			want := FitSmushing | tt.wantRule
+			if got != want {
+				t.Errorf("ToLayout() with rule bit %d = 0x%08X, want 0x%08X",
+					tt.ruleBit, uint32(got), uint32(want))
+			}
+
+			// Verify the specific rule bit is set
+			if got&tt.wantRule == 0 {
+				t.Errorf("ToLayout() missing expected rule %s", tt.wantRule.String())
+			}
+		})
+	}
+}
+
+// TestNormalizeOldLayoutRange tests that NormalizeOldLayout properly validates its input range
+func TestNormalizeOldLayoutRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldLayout int
+		wantErr   bool
+	}{
+		{"Valid: -3 (universal smushing)", -3, false},
+		{"Valid: -2 (fitting alias)", -2, false},
+		{"Valid: -1 (full width)", -1, false},
+		{"Valid: 0 (fitting)", 0, false},
+		{"Valid: 1 (smushing rule 1)", 1, false},
+		{"Valid: 63 (all rules)", 63, false},
+		{"Invalid: -4", -4, true},
+		{"Invalid: -10", -10, true},
+		{"Invalid: -100", -100, true},
+		{"Invalid: 64", 64, true},
+		{"Invalid: 100", 100, true},
+		{"Invalid: 1000", 1000, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NormalizeOldLayout(tt.oldLayout)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeOldLayout(%d) error = %v, wantErr %v",
+					tt.oldLayout, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestFullLayoutPrecedenceMatrix tests that FullLayout always wins when fullLayoutSet=true
+func TestFullLayoutPrecedenceMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldLayout  int
+		fullLayout int
+		wantHorz   AxisMode
+		wantVert   AxisMode
+	}{
+		// FullLayout wins regardless of OldLayout
+		{"Old=-1(full) vs Full=64(fitting)", -1, 64, ModeFitting, ModeFull},
+		{"Old=0(fitting) vs Full=0(default->full)", 0, 0, ModeFull, ModeFull},
+		{"Old=1(smush) vs Full=64(fitting)", 1, 64, ModeFitting, ModeFull},
+		{"Old=63(all rules) vs Full=128(universal)", 63, 128, ModeSmushingUniversal, ModeFull},
+		
+		// Only vertical bits set (no horizontal fit bits)
+		{"Only vertical fitting", -1, 8192, ModeFull, ModeFitting},
+		{"Only vertical smushing", 0, 16384, ModeFull, ModeSmushingUniversal},
+		{"Only vertical controlled", 1, 16384 | 256, ModeFull, ModeSmushingControlled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NormalizeLayoutFromHeader(tt.oldLayout, tt.fullLayout, true)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result.HorzMode != tt.wantHorz {
+				t.Errorf("HorzMode = %v, want %v", result.HorzMode, tt.wantHorz)
+			}
+			if result.VertMode != tt.wantVert {
+				t.Errorf("VertMode = %v, want %v", result.VertMode, tt.wantVert)
+			}
+		})
+	}
+}
+
+// TestBothFitBitsInFullLayout tests that smushing wins when both fitting and smushing bits are set
+func TestBothFitBitsInFullLayout(t *testing.T) {
+	tests := []struct {
+		name       string  
+		fullLayout int
+		wantHorz   AxisMode
+		wantVert   AxisMode
+	}{
+		// Horizontal: both 64(fitting) and 128(smushing) set
+		{"H: both bits, no rules -> universal", 64 | 128, ModeSmushingUniversal, ModeFull},
+		{"H: both bits, with rules -> controlled", 64 | 128 | 3, ModeSmushingControlled, ModeFull},
+		
+		// Vertical: both 8192(fitting) and 16384(smushing) set
+		{"V: both bits, no rules -> universal", 8192 | 16384, ModeFull, ModeSmushingUniversal},
+		{"V: both bits, with rules -> controlled", 8192 | 16384 | 256, ModeFull, ModeSmushingControlled},
+		
+		// Both axes with conflicts
+		{"Both axes conflicts", 64 | 128 | 8192 | 16384, ModeSmushingUniversal, ModeSmushingUniversal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NormalizeLayoutFromHeader(0, tt.fullLayout, true)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result.HorzMode != tt.wantHorz {
+				t.Errorf("HorzMode = %v, want %v", result.HorzMode, tt.wantHorz)
+			}
+			if result.VertMode != tt.wantVert {
+				t.Errorf("VertMode = %v, want %v", result.VertMode, tt.wantVert)
+			}
+		})
+	}
+}
+
+// TestUniversalVsControlledSmushing tests the distinction between universal and controlled smushing
+func TestUniversalVsControlledSmushing(t *testing.T) {
+	tests := []struct {
+		name          string
+		fullLayout    int
+		wantHorzMode  AxisMode
+		wantHorzRules uint8
+		wantVertMode  AxisMode  
+		wantVertRules uint8
+	}{
+		// Horizontal
+		{"H: smushing bit only -> universal", 128, ModeSmushingUniversal, 0, ModeFull, 0},
+		{"H: smushing + rule 1 -> controlled", 128 | 1, ModeSmushingControlled, 1, ModeFull, 0},
+		{"H: smushing + rules 1,3,5 -> controlled", 128 | 1 | 4 | 16, ModeSmushingControlled, 0x15, ModeFull, 0},
+		{"H: smushing + all rules -> controlled", 128 | 63, ModeSmushingControlled, 0x3F, ModeFull, 0},
+		
+		// Vertical  
+		{"V: smushing bit only -> universal", 16384, ModeFull, 0, ModeSmushingUniversal, 0},
+		{"V: smushing + rule 1 -> controlled", 16384 | 256, ModeFull, 0, ModeSmushingControlled, 1},
+		{"V: smushing + rules 1,2,3 -> controlled", 16384 | 256 | 512 | 1024, ModeFull, 0, ModeSmushingControlled, 7},
+		{"V: smushing + all 5 rules -> controlled", 16384 | (31 << 8), ModeFull, 0, ModeSmushingControlled, 0x1F},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NormalizeLayoutFromHeader(0, tt.fullLayout, true)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result.HorzMode != tt.wantHorzMode {
+				t.Errorf("HorzMode = %v, want %v", result.HorzMode, tt.wantHorzMode)
+			}
+			if result.HorzRules != tt.wantHorzRules {
+				t.Errorf("HorzRules = 0x%02X, want 0x%02X", result.HorzRules, tt.wantHorzRules)
+			}
+			if result.VertMode != tt.wantVertMode {
+				t.Errorf("VertMode = %v, want %v", result.VertMode, tt.wantVertMode)
+			}
+			if result.VertRules != tt.wantVertRules {
+				t.Errorf("VertRules = 0x%02X, want 0x%02X", result.VertRules, tt.wantVertRules)
+			}
+		})
+	}
+}
+
+// TestNormalizeLayoutDefaulting tests that NormalizeLayout properly defaults when only rule bits are present
+func TestNormalizeLayoutDefaulting(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Layout
+		want  Layout
+	}{
+		{"No bits -> FitFullWidth", 0, FitFullWidth},
+		{"Only RuleEqualChar -> FitFullWidth preserved", RuleEqualChar, FitFullWidth | RuleEqualChar},
+		{"Only rules 1,3,5 -> FitFullWidth preserved", RuleEqualChar | RuleHierarchy | RuleBigX, 
+			FitFullWidth | RuleEqualChar | RuleHierarchy | RuleBigX},
+		{"All rules, no fit -> FitFullWidth preserved", 
+			RuleEqualChar | RuleUnderscore | RuleHierarchy | RuleOppositePair | RuleBigX | RuleHardblank,
+			FitFullWidth | RuleEqualChar | RuleUnderscore | RuleHierarchy | RuleOppositePair | RuleBigX | RuleHardblank},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLayout(tt.input)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeLayout(0x%08X) = 0x%08X, want 0x%08X",
+					uint32(tt.input), uint32(got), uint32(tt.want))
+			}
+			// Verify rules are preserved
+			if got.Rules() != tt.input.Rules() {
+				t.Errorf("Rules not preserved: got 0x%08X, want 0x%08X",
+					uint32(got.Rules()), uint32(tt.input.Rules()))
+			}
+		})
+	}
+}
+
+// TestLayoutStringWithInvalid tests that Layout.String() properly handles invalid states
+func TestLayoutStringWithInvalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		layout Layout
+		want   string
+	}{
+		{"Single mode", FitFullWidth, "FitFullWidth"},
+		{"Conflict 2 modes", FitKerning | FitSmushing, "INVALID:FitKerning|FitSmushing"},
+		{"Conflict 3 modes", FitFullWidth | FitKerning | FitSmushing, "INVALID:FitFullWidth|FitKerning|FitSmushing"},
+		{"Valid with rules", FitSmushing | RuleEqualChar | RuleBigX, "FitSmushing|RuleEqualChar|RuleBigX"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.layout.String()
+			if got != tt.want {
+				t.Errorf("Layout.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAxisModeString tests the AxisMode String method
+func TestAxisModeString(t *testing.T) {
+	tests := []struct {
+		mode AxisMode
+		want string
+	}{
+		{ModeFull, "Full"},
+		{ModeFitting, "Fitting"},
+		{ModeSmushingControlled, "SmushingControlled"},
+		{ModeSmushingUniversal, "SmushingUniversal"},
+		{AxisMode(99), "Unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("AxisMode.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizedLayoutString tests the NormalizedLayout String method
+func TestNormalizedLayoutString(t *testing.T) {
+	nl := NormalizedLayout{
+		HorzMode:  ModeSmushingControlled,
+		HorzRules: 0x15,
+		VertMode:  ModeFitting,
+		VertRules: 0,
+	}
+
+	want := "Horz:SmushingControlled(rules:0x15) Vert:Fitting(rules:0x00)"
+	got := nl.String()
+	if got != want {
+		t.Errorf("NormalizedLayout.String() = %q, want %q", got, want)
 	}
 }

--- a/layout_test.go
+++ b/layout_test.go
@@ -196,48 +196,48 @@ func TestLayoutNormalizationFromOldLayout(t *testing.T) {
 		want      Layout
 	}{
 		{
-			name:      "full width mode",
+			name:      "fitting (kerning) mode",
 			oldLayout: 0,
-			want:      FitFullWidth,
-		},
-		{
-			name:      "kerning mode",
-			oldLayout: 1,
 			want:      FitKerning,
 		},
 		{
 			name:      "smushing with equal char",
-			oldLayout: 2, // Smushing + equal char rule (bit 0 in old format)
+			oldLayout: 1, // Smushing + equal char rule (bit 0)
 			want:      FitSmushing | RuleEqualChar,
 		},
 		{
 			name:      "smushing with underscore",
-			oldLayout: 4, // Smushing + underscore rule (bit 1 in old format)
+			oldLayout: 2, // Smushing + underscore rule (bit 1)
 			want:      FitSmushing | RuleUnderscore,
 		},
 		{
 			name:      "smushing with hierarchy",
-			oldLayout: 8, // Smushing + hierarchy rule (bit 2 in old format)
+			oldLayout: 4, // Smushing + hierarchy rule (bit 2)
 			want:      FitSmushing | RuleHierarchy,
 		},
 		{
 			name:      "smushing with opposite pair",
-			oldLayout: 16, // Smushing + opposite pair rule (bit 3 in old format)
+			oldLayout: 8, // Smushing + opposite pair rule (bit 3)
 			want:      FitSmushing | RuleOppositePair,
 		},
 		{
 			name:      "smushing with big x",
-			oldLayout: 32, // Smushing + big x rule (bit 4 in old format)
+			oldLayout: 16, // Smushing + big x rule (bit 4)
 			want:      FitSmushing | RuleBigX,
 		},
 		{
 			name:      "smushing with hardblank",
-			oldLayout: 64, // Smushing + hardblank rule (bit 5 in old format)
+			oldLayout: 32, // Smushing + hardblank rule (bit 5)
 			want:      FitSmushing | RuleHardblank,
 		},
 		{
+			name:      "smushing with multiple rules",
+			oldLayout: 3, // bits 0+1 = equal char + underscore
+			want:      FitSmushing | RuleEqualChar | RuleUnderscore,
+		},
+		{
 			name:      "smushing with all rules",
-			oldLayout: 126,
+			oldLayout: 63, // All 6 rule bits
 			want:      FitSmushing | RuleEqualChar | RuleUnderscore | RuleHierarchy | RuleOppositePair | RuleBigX | RuleHardblank,
 		},
 		{

--- a/types.go
+++ b/types.go
@@ -7,13 +7,16 @@ import "errors"
 // Font data is loaded once and never modified, making it safe for concurrent use
 // without locking.
 type Font struct {
-	// Glyphs maps runes to their multi-line ASCII art representations
-	Glyphs map[rune][]string
+	// glyphs maps runes to their multi-line ASCII art representations (unexported for immutability)
+	glyphs map[rune][]string
 
 	// Name is the font name (e.g., "standard")
 	Name string
 
-	// FullLayout contains the full layout bitmask combining fitting mode and smushing rules
+	// FullLayout contains the normalized horizontal layout bitmask combining fitting mode and smushing rules.
+	// Note: This is NOT the raw FullLayout value from the FIGfont header.
+	// It's the normalized renderer layout derived from the header's OldLayout/FullLayout values.
+	// Only horizontal layout is currently used by the renderer.
 	FullLayout Layout
 
 	// Hardblank is the character used for hard blanks in the font
@@ -36,6 +39,16 @@ type Font struct {
 
 	// CommentLines is the number of comment lines in the font file
 	CommentLines int
+}
+
+// Glyph returns the ASCII art representation for a rune, or false if not found.
+// The returned slice should not be modified by the caller.
+func (f *Font) Glyph(r rune) ([]string, bool) {
+	if f == nil || f.glyphs == nil {
+		return nil, false
+	}
+	glyph, ok := f.glyphs[r]
+	return glyph, ok
 }
 
 // Common errors returned by the figgo package

--- a/types_test.go
+++ b/types_test.go
@@ -17,7 +17,7 @@ func TestFontStruct(t *testing.T) {
 		FullLayout:     FitFullWidth,
 		PrintDirection: 0,
 		CommentLines:   25,
-		Glyphs:         make(map[rune][]string),
+		glyphs:         make(map[rune][]string),
 	}
 
 	if font.Name != "standard" {
@@ -47,8 +47,8 @@ func TestFontStruct(t *testing.T) {
 	if font.CommentLines != 25 {
 		t.Errorf("expected CommentLines to be 25, got %d", font.CommentLines)
 	}
-	if font.Glyphs == nil {
-		t.Error("expected Glyphs to be initialized")
+	if font.glyphs == nil {
+		t.Error("expected glyphs to be initialized")
 	}
 }
 
@@ -83,5 +83,45 @@ func TestOptionPattern(t *testing.T) {
 	opt = WithPrintDirection(1)
 	if opt == nil {
 		t.Error("WithPrintDirection should return an Option")
+	}
+}
+
+func TestFontGlyphAccessor(t *testing.T) {
+	font := &Font{
+		glyphs: map[rune][]string{
+			'A': {"  A  ", " A A ", "AAAAA", "A   A", "A   A"},
+			'B': {"BBBB ", "B   B", "BBBB ", "B   B", "BBBB "},
+		},
+	}
+
+	// Test successful glyph retrieval
+	glyph, ok := font.Glyph('A')
+	if !ok {
+		t.Error("expected to find glyph for 'A'")
+	}
+	if len(glyph) != 5 {
+		t.Errorf("expected glyph to have 5 lines, got %d", len(glyph))
+	}
+
+	// Test missing glyph
+	_, ok = font.Glyph('Z')
+	if ok {
+		t.Error("expected not to find glyph for 'Z'")
+	}
+
+	// Test nil font
+	var nilFont *Font
+	_, ok = nilFont.Glyph('A')
+	if ok {
+		t.Error("expected nil font to return false")
+	}
+
+	// Verify immutability - modifying returned slice shouldn't affect font
+	// Note: In Go, slices share backing arrays, so this tests that
+	// callers understand they shouldn't modify the returned data
+	glyph, _ = font.Glyph('B')
+	originalLine := glyph[0]
+	if originalLine != "BBBB " {
+		t.Errorf("unexpected original line: %q", originalLine)
 	}
 }


### PR DESCRIPTION
## Summary
- Completes spec-compliant FIGfont v2 layout normalization implementation
- Adds comprehensive validation, testing, and debugging capabilities
- Makes Font type immutable for thread safety

## Changes

### Core Improvements
- **Range validation**: OldLayout constrained to [-3..63], FullLayout to [0..32767]
- **Font immutability**: Made `Font.glyphs` unexported, added `Glyph()` accessor method
- **Smart defaults**: Render options now default to font's layout/direction when not specified
- **Unknown bit masking**: NormalizeLayout masks unknown bits to prevent garbage propagation
- **Rule bit documentation**: Clarified that rule bits are preserved but ignored unless FitSmushing is active

### Parser Enhancements
- MaxLength violations now generate warnings instead of errors (advisory per spec)
- Added UTF-8 BOM stripping in font header parsing
- Improved integer overflow handling to satisfy gosec

### Debugging & Diagnostics
- Added `String()` methods for `NormalizedLayout` and `AxisMode`
- Layout.String() now prefixes "INVALID:" for conflicting fitting modes
- Better error messages throughout

### Testing
- Added test for ToLayout() mapping completeness (bits 0-5 → rules)
- Added test for OldLayout range validation
- Added FullLayout precedence matrix tests
- Added tests for both fit bits set (smushing wins)
- Added universal vs controlled smushing tests
- Added NormalizeLayout defaulting tests

## Test Plan
- [x] All existing tests pass
- [x] New comprehensive test suite added
- [x] Race detection passes
- [x] Linting passes (except complexity warning in test)