### PR TITLE
feat: implement universal smushing

### DIFF
--- a/internal/renderer/smushing.go
+++ b/internal/renderer/smushing.go
@@ -153,7 +153,32 @@ func smushPair(left, right rune, layout int, hardblank rune) (rune, bool) {
 		return right, true
 	}
 
-	// Controlled rules are defined but none matched - no smushing possible
+	// Controlled rules are defined but none matched
+	// Fall back to universal smushing, but with restrictions:
+	// - Hardblank collisions are NOT allowed
+	// - Only space vs visible character combinations are allowed
+
+	// Block hardblank collisions
+	if left == hardblank || right == hardblank {
+		return 0, false
+	}
+
+	// Universal smushing fallback rules:
+	// - If left is space and right is visible → take right
+	// - If right is space and left is visible → take left
+	// - If both are spaces → take space (allow overlap)
+	// - If both are visible → no smush (fall back to kerning)
+	if left == ' ' && right != ' ' {
+		return right, true
+	}
+	if right == ' ' && left != ' ' {
+		return left, true
+	}
+	if left == ' ' && right == ' ' {
+		return ' ', true // Both spaces - allow overlap with space
+	}
+
+	// Both visible - no smushing possible
 	return 0, false
 }
 

--- a/internal/renderer/smushing.go
+++ b/internal/renderer/smushing.go
@@ -174,6 +174,14 @@ func smushPair(left, right rune, layout int, hardblank rune) (rune, bool) {
 	}
 
 	// Universal smushing fallback rules for other combinations:
+	// Special case: hardblank vs space - "later wins" (universal override principle)
+	if left == hardblank && right == ' ' {
+		return ' ', true // Later (right) wins
+	}
+	if left == ' ' && right == hardblank {
+		return hardblank, true // Later (right) wins
+	}
+
 	// - If left is space and right is visible → take right
 	// - If right is space and left is visible → take left
 	// - If both are spaces → take space (allow overlap)

--- a/internal/renderer/smushing.go
+++ b/internal/renderer/smushing.go
@@ -142,6 +142,13 @@ func smushPair(left, right rune, layout int, hardblank rune) (rune, bool) {
 	if !hasRules {
 		// Universal smushing (only when NO controlled rules are defined)
 		// Per spec: later character overrides earlier at overlapping position
+		// But hardblank vs hardblank is NOT allowed (only via Rule 6)
+
+		// Block hardblank vs hardblank collision
+		if left == hardblank && right == hardblank {
+			return 0, false
+		}
+
 		// Visible chars override spaces AND hardblanks
 		if right != ' ' && right != hardblank {
 			return right, true // Right (later) char overrides
@@ -149,7 +156,7 @@ func smushPair(left, right rune, layout int, hardblank rune) (rune, bool) {
 		if left != ' ' && left != hardblank {
 			return left, true // Keep left if right is space/hardblank
 		}
-		// Both are space or hardblank - keep the override (right)
+		// Both are space or one is hardblank with space - keep the override (right)
 		return right, true
 	}
 

--- a/internal/renderer/smushing_test.go
+++ b/internal/renderer/smushing_test.go
@@ -581,7 +581,7 @@ func TestSmushPair(t *testing.T) {
 			layout:    layoutSmushing, // Pure universal - no rules
 			hardblank: '$',
 			want:      '$',
-			wantOK:    true, // Hardblank overrides space in pure universal
+			wantOK:    true, // Later char (right) overrides in pure universal
 		},
 	}
 

--- a/internal/renderer/smushing_test.go
+++ b/internal/renderer/smushing_test.go
@@ -363,8 +363,8 @@ func TestSmushPair(t *testing.T) {
 			right:     'A',
 			layout:    layoutSmushing | layoutRule6,
 			hardblank: '$',
-			want:      0,
-			wantOK:    false, // Rule 6 doesn't match, and with controlled rules defined, no universal smushing
+			want:      'A',
+			wantOK:    true, // Rule 6 doesn't match, falls back to universal (visible overrides hardblank)
 		},
 
 		// Precedence tests (multiple rules enabled)
@@ -506,8 +506,8 @@ func TestSmushPair(t *testing.T) {
 			right:     'A',
 			layout:    layoutSmushing | layoutRule1, // Rule 1 enabled but won't match
 			hardblank: '$',
-			want:      0,
-			wantOK:    false, // Universal fallback: hardblank blocks universal smushing
+			want:      'A',
+			wantOK:    true, // Universal fallback: visible overrides hardblank
 		},
 		{
 			name:      "controlled_rules_fallback_hardblank_right",
@@ -515,8 +515,8 @@ func TestSmushPair(t *testing.T) {
 			right:     '$',
 			layout:    layoutSmushing | layoutRule1, // Rule 1 enabled but won't match
 			hardblank: '$',
-			want:      0,
-			wantOK:    false, // Universal fallback: hardblank blocks universal smushing
+			want:      'A',
+			wantOK:    true, // Universal fallback: visible overrides hardblank
 		},
 		{
 			name:      "controlled_rules_fallback_both_hardblanks",
@@ -544,6 +544,44 @@ func TestSmushPair(t *testing.T) {
 			hardblank: '$',
 			want:      '#',
 			wantOK:    true, // Rule 1 matches, no need for fallback
+		},
+
+		// Pure universal mode tests (no controlled rules enabled)
+		{
+			name:      "pure_universal_visible_vs_hardblank_left",
+			left:      '$',
+			right:     'X',
+			layout:    layoutSmushing, // Pure universal - no rules
+			hardblank: '$',
+			want:      'X',
+			wantOK:    true, // Visible overrides hardblank in pure universal
+		},
+		{
+			name:      "pure_universal_visible_vs_hardblank_right",
+			left:      'Y',
+			right:     '$',
+			layout:    layoutSmushing, // Pure universal - no rules
+			hardblank: '$',
+			want:      'Y',
+			wantOK:    true, // Visible overrides hardblank in pure universal
+		},
+		{
+			name:      "pure_universal_hardblank_vs_space_left",
+			left:      '$',
+			right:     ' ',
+			layout:    layoutSmushing, // Pure universal - no rules
+			hardblank: '$',
+			want:      ' ',
+			wantOK:    true, // Later char (right) overrides in pure universal
+		},
+		{
+			name:      "pure_universal_hardblank_vs_space_right",
+			left:      ' ',
+			right:     '$',
+			layout:    layoutSmushing, // Pure universal - no rules
+			hardblank: '$',
+			want:      '$',
+			wantOK:    true, // Hardblank overrides space in pure universal
 		},
 	}
 
@@ -656,12 +694,12 @@ func TestUniversalSmushingMultiColumn(t *testing.T) {
 			wantResult: "A  B",
 		},
 		{
-			name:         "hardblank_blocks_universal",
+			name:         "hardblank_blocks_hardblank",
 			leftLine:     "A$",
 			rightLine:    "$B",
 			overlap:      1,
 			wantCanSmush: false,
-			// Column 1: '$' + '$' → blocked (hardblank collision, no Rule 6)
+			// Column 1: '$' + '$' → blocked (hardblank vs hardblank collision, no Rule 6)
 			wantResult: "",
 		},
 		{

--- a/internal/renderer/smushing_test.go
+++ b/internal/renderer/smushing_test.go
@@ -568,6 +568,15 @@ func TestSmushPair(t *testing.T) {
 
 		// Pure universal mode tests (no controlled rules enabled)
 		{
+			name:      "pure_universal_space_space",
+			left:      ' ',
+			right:     ' ',
+			layout:    layoutSmushing, // no rules
+			hardblank: ',',
+			want:      ' ',
+			wantOK:    true,
+		},
+		{
 			name:      "pure_universal_visible_vs_hardblank_left",
 			left:      '$',
 			right:     'X',

--- a/internal/renderer/smushing_test.go
+++ b/internal/renderer/smushing_test.go
@@ -566,6 +566,26 @@ func TestSmushPair(t *testing.T) {
 			wantOK:    true, // Rule 1 matches, no need for fallback
 		},
 
+		// Fallback universal HB vs space tests (later wins special case)
+		{
+			name:      "fallback_universal_hardblank_vs_space_right_later_wins",
+			left:      ',',
+			right:     ' ',
+			layout:    layoutSmushing | layoutRule1, // rules exist but don't match
+			hardblank: ',',
+			want:      ' ',
+			wantOK:    true,
+		},
+		{
+			name:      "fallback_universal_space_vs_hardblank_right_later_wins",
+			left:      ' ',
+			right:     ',',
+			layout:    layoutSmushing | layoutRule1,
+			hardblank: ',',
+			want:      ',',
+			wantOK:    true,
+		},
+
 		// Pure universal mode tests (no controlled rules enabled)
 		{
 			name:      "pure_universal_space_space",
@@ -574,6 +594,15 @@ func TestSmushPair(t *testing.T) {
 			layout:    layoutSmushing, // no rules
 			hardblank: ',',
 			want:      ' ',
+			wantOK:    true,
+		},
+		{
+			name:      "pure_universal_visible_vs_visible_later_wins",
+			left:      'A',
+			right:     'B',
+			layout:    layoutSmushing, // no rules
+			hardblank: ',',
+			want:      'B', // later wins in pure universal
 			wantOK:    true,
 		},
 		{

--- a/internal/renderer/smushing_test.go
+++ b/internal/renderer/smushing_test.go
@@ -367,6 +367,26 @@ func TestSmushPair(t *testing.T) {
 			wantOK:    true, // Rule 6 doesn't match, falls back to universal (visible overrides hardblank)
 		},
 
+		// Rule 6 precedence tests - ensure Rule 6 takes priority over universal HB-HB block
+		{
+			name:      "rule6_hardblank_smush_applies",
+			left:      ',',
+			right:     ',',
+			layout:    layoutSmushing | layoutRule6, // Rule 6 enabled
+			hardblank: ',',
+			want:      ',', // Rule 6 smushes to a single hardblank
+			wantOK:    true,
+		},
+		{
+			name:      "no_rule6_hardblank_pair_blocks",
+			left:      ',',
+			right:     ',',
+			layout:    layoutSmushing, // universal only
+			hardblank: ',',
+			want:      0,
+			wantOK:    false, // Blocked by universal path
+		},
+
 		// Precedence tests (multiple rules enabled)
 		{
 			name:      "precedence_rule1_over_rule3",
@@ -457,8 +477,8 @@ func TestSmushPair(t *testing.T) {
 			right:     '$',
 			layout:    layoutSmushing, // No Rule 6 enabled
 			hardblank: '$',
-			want:      '$',
-			wantOK:    true, // Universal smushing: later character (right) overrides, even for hardblanks
+			want:      0,
+			wantOK:    false, // HB-HB blocked in universal (only allowed via Rule 6)
 		},
 
 		// No smushing mode (kerning only)


### PR DESCRIPTION
## Summary
- Implements universal smushing per FIGfont v2 specification
- Distinguishes between pure universal mode (no rules) and fallback mode (rules defined but none match)
- Ensures Rule 6 precedence for hardblank smushing

## Implementation Details

### Universal Smushing Modes
1. **Pure Universal Mode** (no controlled rules defined)
   - Later character overrides earlier at overlapping position
   - Visible characters can smush with visible (later wins)
   - Hardblank-hardblank collisions blocked (only via Rule 6)

2. **Fallback Universal Mode** (controlled rules defined but none match)
   - More restrictive than pure universal
   - Visible-visible collisions NOT allowed
   - Space/hardblank combinations follow "later wins" principle

### Key Changes
- Added `universalSmush()` helper function to prevent code drift between modes
- Proper hardblank vs hardblank blocking (only Rule 6 can smush them)
- Comprehensive test coverage for all edge cases
- Fast-path optimizations for common cases

## Test Coverage
- ✅ Pure universal space+space, visible+visible tests
- ✅ Fallback universal HB vs space "later wins" tests  
- ✅ Rule 6 precedence tests
- ✅ Multi-column overlap scenarios
- ✅ All character type combinations

## Fixes #13